### PR TITLE
build: fail dist tests in ci if not updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore: 
+      - dependency-name: "postman-collection"
+        versions: ["4.x"]
+      - dependency-name: "@types/postman-collection"
+        versions: ["4.x"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore: 
-      - dependency-name: "postman-collection"
-        versions: ["4.x"]
-      - dependency-name: "@types/postman-collection"
-        versions: ["4.x"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm i
-      - run: npm run build
+      - run: bazel build ... # do not update dist in ci
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1772,6 +1772,12 @@
         "repeat-string": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
+      "integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+      "dev": true
+    },
     "mdast-builder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/mdast-builder/-/mdast-builder-1.1.1.tgz",
@@ -1997,9 +2003,9 @@
       }
     },
     "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
       "dev": true
     },
     "mime-format": {
@@ -2012,12 +2018,12 @@
       }
     },
     "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+      "version": "2.1.30",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
+      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.47.0"
       }
     },
     "mimic-fn": {
@@ -4423,22 +4429,25 @@
       }
     },
     "postman-collection": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-4.0.1.tgz",
-      "integrity": "sha512-zHPWjAY6mRqbYFiAbtyyi/JsOA3xQRxQgNsdX7fVe6kapsvvR2viPA0U0ck3hYM2mhPUkNqxorOWWvNDKpZKTg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.6.11.tgz",
+      "integrity": "sha512-22oIsOXwigdEGQJuTgS44964hj0/gN20E6/aiDoO469WiqqOk5JEEVQpW8zCDjsb9vynyk384JqE9zRyvfrH5A==",
       "dev": true,
       "requires": {
+        "escape-html": "1.0.3",
         "faker": "5.5.3",
         "file-type": "3.9.0",
         "http-reasons": "0.1.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.6.2",
         "liquid-json": "0.3.1",
         "lodash": "4.17.21",
+        "marked": "2.0.1",
         "mime-format": "2.0.1",
-        "mime-types": "2.1.31",
-        "postman-url-encoder": "3.0.3",
+        "mime-types": "2.1.30",
+        "postman-url-encoder": "3.0.1",
+        "sanitize-html": "1.20.1",
         "semver": "7.3.5",
-        "uuid": "8.3.2"
+        "uuid": "3.4.0"
       },
       "dependencies": {
         "faker": {
@@ -4446,15 +4455,6 @@
           "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
           "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
           "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
         },
         "lodash": {
           "version": "4.17.21",
@@ -4479,19 +4479,13 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
         }
       }
     },
     "postman-url-encoder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.3.tgz",
-      "integrity": "sha512-i+jvi7RakE3k5fAKJYzgKyCU5Rd6G+DnW1nxjCoeg7rR5qBUHw5vJRuGAZEmQYHJe8xgGSS63HIoCZ96DbXdpg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.1.tgz",
+      "integrity": "sha512-dMPqXnkDlstM2Eya+Gw4MIGWEan8TzldDcUKZIhZUsJ/G5JjubfQPhFhVWKzuATDMvwvrWbSjF+8VmAvbu6giw==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "openapi-examples-validator": "^4.4.0",
     "openapi-types": "^9.1.0",
     "postman-code-generators": "^1.1.5",
-    "postman-collection": "^4.0.1",
+    "postman-collection": "^3.6.11",
     "prettier": "^2.3.2",
     "remark-gfm": "^1.0.0",
     "remark-html": "^13.0.1",


### PR DESCRIPTION
The `npm run build` is allowing dependabot changes to be made that change the dist folder. These need to be manually merged.