### PR TITLE
docs: Fix broken link to Bazel in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ An OpenAPI specification for Google Maps Platform APIs.
 
 ## Development
 
-The repository makes use of [Bazel](BUILD.bazel) to generate outputs from the specification and sample requests.
+The repository makes use of [Bazel](https://bazel.build/) to generate outputs from the specification and sample requests.
 
 ### Build and test
 


### PR DESCRIPTION
The current link leads to this URL and which gives a 404:
https://github.com/googlemaps/openapi-specification/blob/main/bazel.build

I think `BUILD.bazel` is the correct file to link to?