### PR TITLE
fix: Close is optional

### DIFF
--- a/specification/schemas/PlaceOpeningHoursPeriod.yml
+++ b/specification/schemas/PlaceOpeningHoursPeriod.yml
@@ -16,7 +16,6 @@ type: object
 title: PlaceOpeningHoursPeriod
 required:
   - open
-  - close
 properties:
   open:
     description: Contains a pair of day and time objects describing when the place opens.


### PR DESCRIPTION
According to the description for the `close` field: ` If a place is always open, the close section will be missing [...]`, close has to be optional.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes https://github.com/googlemaps/openapi-specification/issues/296 🦕
