### PR TITLE
Nearbysearch requires radius param

### DIFF
--- a/specification/parameters/places/radius-required
+++ b/specification/parameters/places/radius-required
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: radius
+description: |
+  Defines the distance (in meters) within which to return place results. You may bias results to a specified circle by passing a `location` and a `radius` parameter. Doing so instructs the Places service to _prefer_ showing results within that circle; results outside of the defined area may still be displayed.
+  
+  The radius will automatically be clamped to a maximum value depending on the type of search and other parameters.
+
+  * Autocomplete: 50,000 meters
+  * Nearby Search: 
+    * with `keyword` or `name`: 50,000 meters
+    * without `keyword` or `name`
+      * Up to 50,000 meters, adjusted dynamically based on area density, independent of `rankby` parameter.
+      * When using `rankby=distance`, the radius parameter will not be accepted, and will result in an `INVALID_REQUEST`.
+  * Query Autocomplete: 50,000 meters
+  * Text Search: 50,000 meters
+required: true
+schema:
+  type: number
+in: query
+example: 1000

--- a/specification/paths/places/nearbysearch.yml
+++ b/specification/paths/places/nearbysearch.yml
@@ -26,7 +26,7 @@ parameters:
   - "$ref": "../../parameters/places/opennow.yml"
   - "$ref": "../../parameters/places/pagetoken.yml"
   - "$ref": "../../parameters/places/rankby.yml"
-  - "$ref": "../../parameters/places/radius.yml"
+  - "$ref": "../../parameters/places/radius-required.yml"
   - "$ref": "../../parameters/places/type.yml"
   - "$ref": "../../parameters/language.yml"
 responses:


### PR DESCRIPTION
Sorry I didn't file an issue, I didn't think there was much to discuss here, but maybe I was wrong :P

Specifying location and radius params works:
`curl -L -X GET 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522%2C151.1957362&radius=1500&key=SOME_KEY'`

But specifying only location doesn't:
`curl -L -X GET 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522%2C151.1957362&key=SOME_KEY'`

[edit]
I just noticed that `radius` is only required when not `rankby` isn't specified, or set to its default value of `prominence`. So omitting `radius` but setting `rankby` to `distance` works:
`curl -L -X GET 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=-33.8670522%2C151.1957362&rankby=distance&key=SOME_KEY'`

Btw, by "doesn't work" I mean this response:
```
{
    "html_attributions": [],
    "results": [],
    "status": "INVALID_REQUEST"
}
```
Anyway, I'm not sure this PR is mergable any more, but I hope it's useful in getting to the bottom of this bug, whether it's in the documentation or behavior. Maybe it's just a matter of updating the [nearby search developer guide](https://developers.google.com/maps/documentation/places/web-service/search-nearby#location).

