### PR TITLE
fix: Adds note to indicate that radius parameter is required

### DIFF
--- a/specification/parameters/places/location.yml
+++ b/specification/parameters/places/location.yml
@@ -14,7 +14,7 @@
 
 name: location
 description: |
-  The point around which to retrieve place information. This must be specified as `latitude,longitude`. 
+  The point around which to retrieve place information. This must be specified as `latitude,longitude`. The `radius` parameter must also be provided when specifying a location. If `radius` is not provided, the `location` parameter is ignored.
   
   <div class="note">When using the Text Search API, the `location` parameter may be overriden if the `query` contains an explicit location such as `Market in Barcelona`.</div>
 schema:


### PR DESCRIPTION
Adds a note to indicate that the radius parameter is required when specifying the location.
Fixes #365  🦕
