### PR TITLE
Add "FUTURE_OPENING" to the business status enum

### DIFF
--- a/specification/schemas/Place.yml
+++ b/specification/schemas/Place.yml
@@ -31,6 +31,7 @@ properties:
     type: string
     enum:
       - OPERATIONAL
+      - FUTURE_OPENING
       - CLOSED_TEMPORARILY
       - CLOSED_PERMANENTLY
   curbside_pickup:


### PR DESCRIPTION
We just saw this come through and break our validation. This change updates the available enum options for Place.business_status to include "FUTURE_OPENING".

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #402 🦕
