### PR TITLE
Places: Update type.yml for Nearby Search

### DIFF
--- a/specification/parameters/places/type.yml
+++ b/specification/parameters/places/type.yml
@@ -16,6 +16,8 @@ name: type
 description: |
   Restricts the results to places matching the specified type. Only one type may be specified. If more than one type is provided, all types following the first entry are ignored.
   
+  If used, results may be limited even where there may be more results. E.g. if type is set to `locality` then the result can be limited to the best 2 matches according to the `radius` or `rankby` parameters.
+  
   * `type=hospital|pharmacy|doctor` becomes `type=hospital`
   * `type=hospital,pharmacy,doctor` is ignored entirely
   

--- a/specification/parameters/places/type.yml
+++ b/specification/parameters/places/type.yml
@@ -14,9 +14,11 @@
 
 name: type
 description: |
-  Restricts the results to places matching the specified type. Only one type may be specified. If more than one type is provided, all types following the first entry are ignored.
+  Restricts the results to places matching the specified type. Only one type may be specified.
   
   If used, results may be limited even where there may be more results. E.g. if type is set to `locality` then the result can be limited to the best 2 matches according to the `radius` or `rankby` parameters.
+  
+  If more than one type is provided, all types following the first entry are ignored.
   
   * `type=hospital|pharmacy|doctor` becomes `type=hospital`
   * `type=hospital,pharmacy,doctor` is ignored entirely


### PR DESCRIPTION
Clarifying that if e.g. `type=locality` is used in **nearby search**, the result may be limited to the best e.g. 2 matches, relative to the `rankby` or `radius` parameters.

Meaning even if there's 4 cities within the results, only 2 will be returned.

See the comments of this answer for an example of this clarifying the necessity of this PR: https://stackoverflow.com/a/74866292/20073186
