### PR TITLE
docs: updates points.yml

### DIFF
--- a/specification/parameters/nearestRoads/points.yml
+++ b/specification/parameters/nearestRoads/points.yml
@@ -14,8 +14,7 @@
 
 name: points
 description: |
-  The path to be snapped. The path parameter accepts a list of latitude/longitude pairs. Latitude and longitude values should be separated by commas. Coordinates should be separated by the pipe character: "|". For example: `path=60.170880,24.942795|60.170879,24.942796|60.170877,24.942796`.
-  <div class="note">Note: The snapping algorithm works best for points that are not too far apart. If you observe odd snapping behavior, try creating paths that have points closer together. To ensure the best snap-to-road quality, you should aim to provide paths on which consecutive pairs of points are within 300m of each other. This will also help in handling any isolated, long jumps between consecutive points caused by GPS signal loss, or noise.</div>
+  The points to be snapped. The points parameter accepts a list of latitude/longitude pairs. Separate latitude and longitude values with commas. Separate coordinates with the pipe character: "|". For example: `points=60.170880,24.942795|60.170879,24.942796|60.170877,24.942796`.
 required: true
 in: query
 style: pipeDelimited


### PR DESCRIPTION
Corrected instances of "path" to "points" to match sample, plus removed note which is relevant for the path parameter in snap to roads, but isn't relevant for nearest roads. 

Fixes #419 🦕