### PR TITLE
chore: update release workflow dependency on semantic-release-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - run: npm run build -- --jobs 8
       - run: npm test -- --jobs 8
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 19
           extra_plugins: |


### PR DESCRIPTION
v3 updates the action's environment from Node 12 to Node 16 and fixes the warnings about set-output deprecation. https://github.com/cycjimmy/semantic-release-action/issues/127