### PR TITLE
fix: removed locationrestriction from findplacefromtext

### DIFF
--- a/specification/paths/places/findplacefromtext.yml
+++ b/specification/paths/places/findplacefromtext.yml
@@ -32,7 +32,6 @@ parameters:
     example: "Museum of Contemporary Art Australia"
   - "$ref": "../../parameters/places/inputtype.yml"
   - "$ref": "../../parameters/places/locationbias.yml"
-  - "$ref": "../../parameters/places/locationrestriction.yml"
   - "$ref": "../../parameters/language.yml"
 responses:
   "200":


### PR DESCRIPTION
As outlined in https://issuetracker.google.com/u/0/issues/265054746, locationrestriction does not exist in findplacefromtext 😊