### PR TITLE
fix: added missing maximum size limitation on static street view api

### DIFF
--- a/specification/parameters/streetview/size.yml
+++ b/specification/parameters/streetview/size.yml
@@ -14,7 +14,7 @@
 
 name: size
 description: |
-  Specifies the output size of the image in pixels. Size is specified as `{width}x{height}` - for example, `size=600x400` returns an image 600 pixels wide, and 400 high.
+  Specifies the output size of the image in pixels. Must not exceed 640 pixels wide or high, anything over will default to 640 pixels. Size is specified as `{width}x{height}` - for example, `size=600x400` returns an image 600 pixels wide, and 400 high.
 schema:
   type: string
 in: query

--- a/specification/parameters/streetview/size.yml
+++ b/specification/parameters/streetview/size.yml
@@ -14,7 +14,7 @@
 
 name: size
 description: |
-  Specifies the output size of the image in pixels. Must not exceed 640 pixels wide or high, anything over will default to 640 pixels. Size is specified as `{width}x{height}` - for example, `size=600x400` returns an image 600 pixels wide, and 400 high.
+  Specifies the output size of the image in pixels. Size is specified as `{width}x{height}` - for example, `size=600x400` returns an image 600 pixels wide, and 400 high.
 schema:
   type: string
 in: query


### PR DESCRIPTION
In the Static Maps API, the limitation is defined in the scale table here:
https://developers.google.com/maps/documentation/maps-static/start#Imagesizes

This is not the case for the Static Street View API since it does not have a scale parameter and therefore is missing this bit of information.
https://developers.google.com/maps/documentation/streetview/request-streetview

Testable against the API at:
https://maps.googleapis.com/maps/api/streetview?location=58.38179744740434%2C12.32747224231328&size=641,640&key=API_KEY

Which produces a 640x640 image: 
![image](https://user-images.githubusercontent.com/78360666/215283496-279b3af4-b810-48c3-8628-b5d15a3446de.png)
