### PR TITLE
fix: made secondary_text response optional

### DIFF
--- a/specification/schemas/PlaceAutocompleteStructuredFormat.yml
+++ b/specification/schemas/PlaceAutocompleteStructuredFormat.yml
@@ -17,7 +17,6 @@ title: PlaceAutocompleteStructuredFormat
 required:
   - main_text
   - main_text_matched_substrings
-  - secondary_text
 properties:
   main_text:
     description: Contains the main text of a prediction, usually the name of the place.


### PR DESCRIPTION
Looks like it was accidentally added as required in https://github.com/googlemaps/openapi-specification/commit/f778035c957635932716da2bc8ce9c3005e35a10 and the secondary_text_matched_substrings description as a whole was added in https://github.com/googlemaps/openapi-specification/commit/3045b8c2f6e03ed8a09a9ed71cb0290d24ade86f.

Resolves #423 and #375