### PR TITLE
docs: indicate that transit trips are available within a limited time window

### DIFF
--- a/specification/parameters/mode.yml
+++ b/specification/parameters/mode.yml
@@ -19,7 +19,7 @@ description: |
   * `driving` (default) indicates standard driving directions or distance using the road network.
   * `walking` requests walking directions or distance via pedestrian paths & sidewalks (where available).
   * `bicycling` requests bicycling directions or distance via bicycle paths & preferred streets (where available).
-  * `transit` requests directions or distance via public transit routes (where available). If you set the mode to transit, you can optionally specify either a `departure_time` or an `arrival_time`. If neither time is specified, the `departure_time` defaults to now (that is, the departure time defaults to the current time). You can also optionally include a `transit_mode` and/or a `transit_routing_preference`.
+  * `transit` requests directions or distance via public transit routes (where available). Transit trips are available for up to 7 days in the past or 100 days in the future. If you set the mode to transit, you can optionally specify either a `departure_time` or an `arrival_time`. If neither time is specified, the `departure_time` defaults to now (that is, the departure time defaults to the current time). You can also optionally include a `transit_mode` and/or a `transit_routing_preference`. 
   
   <div class="note">Note: Both walking and bicycling directions may sometimes not include clear pedestrian or bicycling paths, so these directions will return warnings in the returned result which you must display to the user.</div>
 in: query


### PR DESCRIPTION
Update Directions and Distance Matrix API to indicate that transit directions are available within a more limited time window as explained in https://issuetracker.google.com/284178782

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [✔ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ✔] Appropriate docs were updated (if necessary)

Fixes #462 🦕
